### PR TITLE
This should cause dialyzer to fail

### DIFF
--- a/lib/islands_engine/island.ex
+++ b/lib/islands_engine/island.ex
@@ -25,7 +25,7 @@ defmodule IslandsEngine.Island do
     not MapSet.disjoint?(existing_island.coordinates, new_island.coordinates)
   end
 
-  @spec guess(%Island{}, %Coordinate{}) :: {:hit, %Island{}} | :miss
+  @spec guess(%Island{}, %Coordinate{}) :: {:hit, %Coordinate{}} | :miss
   def guess(%Island{} = island, %Coordinate{} = coordinate) do
     case MapSet.member?(island.coordinates, coordinate) do
       true ->


### PR DESCRIPTION
This is changing the type spec for `Island.guess/2` to say that it is returning a `{:hit, %Coordinate{}}` but it is returning a `{:hit, %Island{}}`.

I'm expecting this to fail.